### PR TITLE
GlotDict Compatibility

### DIFF
--- a/src/translationFillerStyle.css
+++ b/src/translationFillerStyle.css
@@ -476,3 +476,11 @@ button.save-button {
 button.save-button.ready {
     display:none;
 }
+
+table.translations tr.preview.has-glotdict th + .priority + .original::before {
+    margin-left: calc(-0.5em - 45px)!important;
+}
+
+table.translations tr.preview.has-glotdict.has-warnings th+.priority+.original::before {
+    margin-left: calc(-.5em - 48px)!important;
+}


### PR DESCRIPTION
Change GD blue border position to prevent TF buttons strike out.

Before:
![image](https://user-images.githubusercontent.com/65488419/132124808-67c9668c-0683-41bb-abc7-adc8c52a6e5c.png)

After:
![image](https://user-images.githubusercontent.com/65488419/132124828-6415ad52-7032-486d-8919-94442bd5d578.png)


GlotDict 1.7.x will re-enable this feature that adds a border to the left of strings that have a glossary term in original. Because TF displays prio column, that border is over the prio column, so it needs to be moved further to the left. 

If you want to test this, you need to use GD master version. 